### PR TITLE
feat: adjust header colors and stickiness

### DIFF
--- a/src/Components/Header/Header3.jsx
+++ b/src/Components/Header/Header3.jsx
@@ -1,31 +1,13 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Link } from "react-router";
 import Nav from './Nav';
 
 export default function Header3({ variant }) {
   const [mobileToggle, setMobileToggle] = useState(false);
-  const [isSticky, setIsSticky] = useState();
-  const [prevScrollPos, setPrevScrollPos] = useState(0);
   const [searchToggle, setSearchToggle] = useState(false);
 
-  useEffect(() => {
-    const handleScroll = () => {
-      const currentScrollPos = window.scrollY;
-      if (currentScrollPos > prevScrollPos) {
-        setIsSticky('cs-gescout_sticky'); // Scrolling down
-      } else if (currentScrollPos !== 0) {
-        setIsSticky('cs-gescout_show cs-gescout_sticky'); // Scrolling up
-      } else {
-        setIsSticky();
-      }
-      setPrevScrollPos(currentScrollPos);
-    };
-
-    window.addEventListener('scroll', handleScroll);
-    return () => {
-      window.removeEventListener('scroll', handleScroll);
-    };
-  }, [prevScrollPos]);
+  // Determine header style based on variant to control text color
+  const colorStyle = variant === 'header-transparent' ? 'header_style_2_1' : 'header_style_2_2';
 
   return (
     <div>
@@ -51,11 +33,11 @@ export default function Header3({ variant }) {
       `}</style>
 
       <header
-        className={`cs_site_header header_style_2 header_style_2_2 cs_style_1 header_sticky_style1 ${
+        className={`cs_site_header header_style_2 ${colorStyle} cs_style_1 header_sticky_style1 ${
           variant ? variant : ''
         } cs_sticky_header cs_site_header_full_width ${
           mobileToggle ? 'cs_mobile_toggle_active' : ''
-        } ${isSticky ? isSticky : ''}`}
+        } cs-gescout_sticky`}
       >
         <div className="cs_main_header">
           <div className="container">


### PR DESCRIPTION
## Summary
- make header sticky and consistent
- allow hero header to use white text while others use black

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be81b3fd088330815fa69916541163