### PR TITLE
feat: dynamic header logo and colors

### DIFF
--- a/src/Components/Header/Header3.jsx
+++ b/src/Components/Header/Header3.jsx
@@ -8,6 +8,10 @@ export default function Header3({ variant }) {
   const [prevScrollPos, setPrevScrollPos] = useState(0);
   const [searchToggle, setSearchToggle] = useState(false);
 
+  const isHero = variant === 'header-transparent';
+  const logoSrc = isHero ? '/1global1.png' : '/one-globe.png';
+  const textColor = isHero ? '#fff' : '#000';
+
   useEffect(() => {
     const handleScroll = () => {
       const currentScrollPos = window.scrollY;
@@ -51,6 +55,7 @@ export default function Header3({ variant }) {
       `}</style>
 
       <header
+        style={{ color: textColor }}
         className={`cs_site_header header_style_2 header_style_2_2 cs_style_1 header_sticky_style1 ${
           variant ? variant : ''
         } cs_sticky_header cs_site_header_full_width ${
@@ -62,7 +67,7 @@ export default function Header3({ variant }) {
             <div className="cs_main_header_in">
               <div className="cs_main_header_left">
                 <Link className="cs_site_branding" to="/">
-                  <img src="/1global1.png" alt="Logo" />
+                  <img src={logoSrc} alt="Logo" />
                 </Link>
               </div>
 
@@ -78,17 +83,21 @@ export default function Header3({ variant }) {
                   >
                     <span></span>
                   </span>
-                  <Nav setMobileToggle={setMobileToggle} />
+                  <Nav setMobileToggle={setMobileToggle} linkColor={textColor} />
                 </div>
               </div>
 
               <div className="cs_main_header_right">
                 <div className="header-btn d-flex align-items-center">
                   <div className="main-button">
-                    <a onClick={() => setSearchToggle(!searchToggle)} className="search-trigger search-icon">
+                    <a
+                      onClick={() => setSearchToggle(!searchToggle)}
+                      className="search-trigger search-icon"
+                      style={{ color: textColor }}
+                    >
                       <i className="bi bi-search"></i>
                     </a>
-                    <Link to="/blog" className="theme-btn">
+                    <Link to="/blog" className="theme-btn" style={{ color: textColor }}>
                       <span>
                         Newsletter <i className="bi bi-arrow-right"></i>
                       </span>

--- a/src/Components/Header/Nav.jsx
+++ b/src/Components/Header/Nav.jsx
@@ -1,37 +1,37 @@
 import DropDown from './DropDown';
 import { Link } from "react-router";
 
-export default function Nav({ setMobileToggle }) {
+export default function Nav({ setMobileToggle, linkColor }) {
   return (
     <ul className="cs_nav_list fw-medium">
       <li>
-        <Link to="/">Home</Link>
+        <Link to="/" style={{ color: linkColor }}>Home</Link>
       </li>
 
       <li>
-        <Link to="/about" onClick={() => setMobileToggle(false)}>
+        <Link to="/about" onClick={() => setMobileToggle(false)} style={{ color: linkColor }}>
         About Us
         </Link>
       </li>
 
 
       <li>
-        <Link to="/activities" onClick={() => setMobileToggle(false)}>
+        <Link to="/activities" onClick={() => setMobileToggle(false)} style={{ color: linkColor }}>
         Activities
         </Link>
-      </li> 
-      
-      <li>
-        <Link to="/team">Our Team</Link>
-      </li>        
+      </li>
 
       <li>
-        <Link to="/blog" onClick={() => setMobileToggle(false)}>
+        <Link to="/team" style={{ color: linkColor }}>Our Team</Link>
+      </li>
+
+      <li>
+        <Link to="/blog" onClick={() => setMobileToggle(false)} style={{ color: linkColor }}>
           Blog
         </Link>
-        
+
       </li>
-      
+
     </ul>
   );
 }


### PR DESCRIPTION
## Summary
- toggle between `1global1.png` and `one-globe.png` based on hero header variant
- adjust header and nav text color to white on hero and black elsewhere

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be908d433483309b58f0c46785b5a0