### PR TITLE
feat: dynamic header logo and colors

### DIFF
--- a/src/Components/Header/Header3.jsx
+++ b/src/Components/Header/Header3.jsx
@@ -61,7 +61,7 @@ export default function Header3({ variant }) {
             <div className="cs_main_header_in">
               <div className="cs_main_header_left">
                 <Link className="cs_site_branding" to="/">
-                  <img src={logoSrc} alt="Logo" />
+                  <img src={logoSrc} alt="One Global logo" />
                 </Link>
               </div>
 

--- a/src/Components/Header/Header3.jsx
+++ b/src/Components/Header/Header3.jsx
@@ -5,7 +5,12 @@ import Nav from './Nav';
 export default function Header3({ variant }) {
   const [mobileToggle, setMobileToggle] = useState(false);
   const [searchToggle, setSearchToggle] = useState(false);
-  const [hasScrolled, setHasScrolled] = useState(false);
+  const [hasScrolled, setHasScrolled] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return sessionStorage.getItem('hasScrolled') === 'true';
+    }
+    return false;
+  });
 
   const isHero = variant === 'header-transparent' && !hasScrolled;
   const logoSrc = isHero ? '/1global1.png' : '/one-globe.png';
@@ -14,6 +19,7 @@ export default function Header3({ variant }) {
   useEffect(() => {
     const handleScroll = () => {
       if (window.scrollY > 0) {
+        sessionStorage.setItem('hasScrolled', 'true');
         setHasScrolled(true);
       }
     };

--- a/src/Components/Header/Header3.jsx
+++ b/src/Components/Header/Header3.jsx
@@ -4,28 +4,25 @@ import Nav from './Nav';
 
 export default function Header3({ variant }) {
   const [mobileToggle, setMobileToggle] = useState(false);
-  const [isSticky, setIsSticky] = useState();
-  const [prevScrollPos, setPrevScrollPos] = useState(0);
   const [searchToggle, setSearchToggle] = useState(false);
+  const [hasScrolled, setHasScrolled] = useState(false);
+
+  const isHero = variant === 'header-transparent' && !hasScrolled;
+  const logoSrc = isHero ? '/1global1.png' : '/one-globe.png';
+  const textColor = isHero ? '#fff' : '#000';
 
   useEffect(() => {
     const handleScroll = () => {
-      const currentScrollPos = window.scrollY;
-      if (currentScrollPos > prevScrollPos) {
-        setIsSticky('cs-gescout_sticky'); // Scrolling down
-      } else if (currentScrollPos !== 0) {
-        setIsSticky('cs-gescout_show cs-gescout_sticky'); // Scrolling up
-      } else {
-        setIsSticky();
+      if (window.scrollY > 0) {
+        setHasScrolled(true);
       }
-      setPrevScrollPos(currentScrollPos);
     };
 
     window.addEventListener('scroll', handleScroll);
     return () => {
       window.removeEventListener('scroll', handleScroll);
     };
-  }, [prevScrollPos]);
+  }, []);
 
   return (
     <div>
@@ -37,11 +34,6 @@ export default function Header3({ variant }) {
           display: block;
           object-fit: contain;
         }
-        /* When header becomes sticky, gently reduce the logo size */
-        .cs_sticky_header .cs_site_branding img,
-        .cs-gescout_sticky .cs_site_branding img {
-          height: clamp(34px, 4.2vw, 56px);
-        }
         /* Ensure the img never overflows its container */
         .cs_main_header_left .cs_site_branding {
           display: inline-flex;
@@ -51,18 +43,19 @@ export default function Header3({ variant }) {
       `}</style>
 
       <header
+        style={{ color: textColor }}
         className={`cs_site_header header_style_2 header_style_2_2 cs_style_1 header_sticky_style1 ${
           variant ? variant : ''
         } cs_sticky_header cs_site_header_full_width ${
           mobileToggle ? 'cs_mobile_toggle_active' : ''
-        } ${isSticky ? isSticky : ''}`}
+        }`}
       >
         <div className="cs_main_header">
           <div className="container">
             <div className="cs_main_header_in">
               <div className="cs_main_header_left">
                 <Link className="cs_site_branding" to="/">
-                  <img src="/1global1.png" alt="Logo" />
+                  <img src={logoSrc} alt="Logo" />
                 </Link>
               </div>
 
@@ -85,10 +78,14 @@ export default function Header3({ variant }) {
               <div className="cs_main_header_right">
                 <div className="header-btn d-flex align-items-center">
                   <div className="main-button">
-                    <a onClick={() => setSearchToggle(!searchToggle)} className="search-trigger search-icon">
+                    <a
+                      onClick={() => setSearchToggle(!searchToggle)}
+                      className="search-trigger search-icon"
+                      style={{ color: textColor }}
+                    >
                       <i className="bi bi-search"></i>
                     </a>
-                    <Link to="/blog" className="theme-btn">
+                    <Link to="/blog" className="theme-btn" style={{ color: textColor }}>
                       <span>
                         Newsletter <i className="bi bi-arrow-right"></i>
                       </span>

--- a/src/Components/Header/Nav.jsx
+++ b/src/Components/Header/Nav.jsx
@@ -1,37 +1,34 @@
-import DropDown from './DropDown';
 import { Link } from "react-router";
 
 export default function Nav({ setMobileToggle }) {
   return (
     <ul className="cs_nav_list fw-medium">
       <li>
-        <Link to="/">Home</Link>
+        <Link to="/" style={{ color: 'inherit' }}>Home</Link>
       </li>
 
       <li>
-        <Link to="/about" onClick={() => setMobileToggle(false)}>
-        About Us
+        <Link to="/about" onClick={() => setMobileToggle(false)} style={{ color: 'inherit' }}>
+          About Us
         </Link>
       </li>
 
-
       <li>
-        <Link to="/activities" onClick={() => setMobileToggle(false)}>
-        Activities
+        <Link to="/activities" onClick={() => setMobileToggle(false)} style={{ color: 'inherit' }}>
+          Activities
         </Link>
-      </li> 
-      
-      <li>
-        <Link to="/team">Our Team</Link>
-      </li>        
+      </li>
 
       <li>
-        <Link to="/blog" onClick={() => setMobileToggle(false)}>
+        <Link to="/team" style={{ color: 'inherit' }}>Our Team</Link>
+      </li>
+
+      <li>
+        <Link to="/blog" onClick={() => setMobileToggle(false)} style={{ color: 'inherit' }}>
           Blog
         </Link>
-        
       </li>
-      
+
     </ul>
   );
 }


### PR DESCRIPTION
## Summary
- toggle between `1global1.png` and `one-globe.png` based on hero header variant, switching permanently after the first scroll
- have navigation links inherit the header’s text color
- keep header position and sizing stable while scrolling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be908d433483309b58f0c46785b5a0