### PR TITLE
Switch hero navbar logo and color after scroll

### DIFF
--- a/src/Components/Header/Header3.jsx
+++ b/src/Components/Header/Header3.jsx
@@ -13,14 +13,7 @@ export default function Header3({ variant }) {
   const logoSrc = isHero ? '/1global1.png' : '/one-globe.png';
   const textColor = isHero ? '#fff' : '#000';
 
-  const isHero = variant === 'header-transparent';
-  const logoSrc = isHero ? '/1global1.png' : '/one-globe.png';
-  const textColor = isHero ? '#fff' : '#000';
-
   useEffect(() => {
-    const heroHeight =
-      document.querySelector('.hero-section')?.offsetHeight || 0;
-
     const handleScroll = () => {
       const currentScrollPos = window.scrollY;
 
@@ -33,7 +26,7 @@ export default function Header3({ variant }) {
       }
 
       setPrevScrollPos(currentScrollPos);
-      setHasScrolled(currentScrollPos >= heroHeight);
+      setHasScrolled(currentScrollPos > 0);
     };
 
     window.addEventListener('scroll', handleScroll);

--- a/src/Pages/Home3.jsx
+++ b/src/Pages/Home3.jsx
@@ -17,10 +17,13 @@ const Home3 = () => {
     return (
         <div>
             <Heroanner1></Heroanner1>
-            <About1></About1>
-            <Category1></Category1>
-            <Blog1></Blog1>
-            <Brand1></Brand1>
+            <div className="cs_site_header_spacing_140"></div>
+            <div style={{ marginTop: '-146px', paddingTop: '146px' }}>
+                <About1></About1>
+                <Category1></Category1>
+                <Blog1></Blog1>
+                <Brand1></Brand1>
+            </div>
         </div>
     );
 };


### PR DESCRIPTION
## Summary
- Show a white 1global1.png logo and light navigation links over the hero section
- Swap to the black one-globe.png logo and dark links once the page is scrolled or on other pages
- Prevent the sticky header from overlapping the About section by adding spacer and offset wrapper

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bea171f8a08330af799b7adde191cb