### PR TITLE
Switch hero navbar logo and color after scroll

### DIFF
--- a/src/Components/Header/Header3.jsx
+++ b/src/Components/Header/Header3.jsx
@@ -1,13 +1,13 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Link } from "react-router";
 import Nav from './Nav';
 
 export default function Header3({ variant }) {
   const [mobileToggle, setMobileToggle] = useState(false);
   const [isSticky, setIsSticky] = useState();
-  const [prevScrollPos, setPrevScrollPos] = useState(0);
+  const prevScrollPos = useRef(0);
   const [searchToggle, setSearchToggle] = useState(false);
-  const [hasScrolled, setHasScrolled] = useState(false);
+  const [hasScrolled, setHasScrolled] = useState(variant !== 'header-transparent');
 
   const isHero = variant === 'header-transparent' && !hasScrolled;
   const logoSrc = isHero ? '/1global1.png' : '/one-globe.png';
@@ -17,7 +17,7 @@ export default function Header3({ variant }) {
     const handleScroll = () => {
       const currentScrollPos = window.scrollY;
 
-      if (currentScrollPos > prevScrollPos) {
+      if (currentScrollPos > prevScrollPos.current) {
         setIsSticky('cs-gescout_sticky'); // Scrolling down
       } else if (currentScrollPos !== 0) {
         setIsSticky('cs-gescout_show cs-gescout_sticky'); // Scrolling up
@@ -25,15 +25,16 @@ export default function Header3({ variant }) {
         setIsSticky();
       }
 
-      setPrevScrollPos(currentScrollPos);
-      setHasScrolled(currentScrollPos > 0);
+      prevScrollPos.current = currentScrollPos;
+      setHasScrolled((prev) => prev || currentScrollPos > 0);
     };
 
     window.addEventListener('scroll', handleScroll);
+    setHasScrolled((prev) => prev || window.scrollY > 0);
     return () => {
       window.removeEventListener('scroll', handleScroll);
     };
-  }, [prevScrollPos]);
+  }, []);
 
   return (
     <div>

--- a/src/Components/Header/Header3.jsx
+++ b/src/Components/Header/Header3.jsx
@@ -13,14 +13,7 @@ export default function Header3({ variant }) {
   const logoSrc = isHero ? '/1global1.png' : '/one-globe.png';
   const textColor = isHero ? '#fff' : '#000';
 
-  const isHero = variant === 'header-transparent';
-  const logoSrc = isHero ? '/1global1.png' : '/one-globe.png';
-  const textColor = isHero ? '#fff' : '#000';
-
   useEffect(() => {
-    const heroHeight =
-      document.querySelector('.hero-section')?.offsetHeight || 0;
-
     const handleScroll = () => {
       const currentScrollPos = window.scrollY;
 
@@ -33,7 +26,7 @@ export default function Header3({ variant }) {
       }
 
       setPrevScrollPos(currentScrollPos);
-      setHasScrolled(currentScrollPos >= heroHeight);
+      setHasScrolled(currentScrollPos > 0);
     };
 
     window.addEventListener('scroll', handleScroll);

--- a/src/Components/Header/Header3.jsx
+++ b/src/Components/Header/Header3.jsx
@@ -28,11 +28,6 @@ export default function Header3({ variant }) {
       }
 
       prevScrollPos.current = currentScrollPos;
-
-      if (!hasScrolledRef.current && currentScrollPos > 0) {
-        hasScrolledRef.current = true;
-        setHasScrolled(true); // Permanently switch to dark variant
-      }
     };
 
     window.addEventListener('scroll', handleScroll);
@@ -41,6 +36,23 @@ export default function Header3({ variant }) {
       window.removeEventListener('scroll', handleScroll);
     };
   }, []);
+
+  useEffect(() => {
+    if (variant !== 'header-transparent' || hasScrolledRef.current) return;
+    const sentinel = document.getElementById('hero-sentinel');
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      const entry = entries[0];
+      if (entry.isIntersecting) {
+        hasScrolledRef.current = true;
+        setHasScrolled(true); // Permanently switch to dark variant
+      }
+    });
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [variant]);
 
   return (
     <div>

--- a/src/Components/Header/Header3.jsx
+++ b/src/Components/Header/Header3.jsx
@@ -7,7 +7,9 @@ export default function Header3({ variant }) {
   const [isSticky, setIsSticky] = useState();
   const prevScrollPos = useRef(0);
   const [searchToggle, setSearchToggle] = useState(false);
-  const [hasScrolled, setHasScrolled] = useState(variant !== 'header-transparent');
+  // Track if the user has scrolled at least once to lock the dark navbar
+  const hasScrolledRef = useRef(variant !== 'header-transparent');
+  const [hasScrolled, setHasScrolled] = useState(hasScrolledRef.current);
 
   const isHero = variant === 'header-transparent' && !hasScrolled;
   const logoSrc = isHero ? '/1global1.png' : '/one-globe.png';
@@ -26,11 +28,15 @@ export default function Header3({ variant }) {
       }
 
       prevScrollPos.current = currentScrollPos;
-      setHasScrolled((prev) => prev || currentScrollPos > 0);
+
+      if (!hasScrolledRef.current && currentScrollPos > 0) {
+        hasScrolledRef.current = true;
+        setHasScrolled(true); // Permanently switch to dark variant
+      }
     };
 
     window.addEventListener('scroll', handleScroll);
-    setHasScrolled((prev) => prev || window.scrollY > 0);
+    handleScroll(); // Set initial state based on current scroll
     return () => {
       window.removeEventListener('scroll', handleScroll);
     };

--- a/src/Pages/Home3.jsx
+++ b/src/Pages/Home3.jsx
@@ -17,10 +17,12 @@ const Home3 = () => {
     return (
         <div>
             <Heroanner1></Heroanner1>
-            <About1></About1>
-            <Category1></Category1>
-            <Blog1></Blog1>
-            <Brand1></Brand1>
+            <div style={{ marginTop: '-140px', paddingTop: '140px' }}>
+                <About1></About1>
+                <Category1></Category1>
+                <Blog1></Blog1>
+                <Brand1></Brand1>
+            </div>
         </div>
     );
 };

--- a/src/Pages/Home3.jsx
+++ b/src/Pages/Home3.jsx
@@ -9,7 +9,7 @@ const Home3 = () => {
     return (
         <div>
             <Heroanner1></Heroanner1>
-            <div className="after-hero-offset">
+            <div id="hero-sentinel" className="after-hero-offset">
                 <About1></About1>
                 <Category1></Category1>
                 <Blog1></Blog1>

--- a/src/Pages/Home3.jsx
+++ b/src/Pages/Home3.jsx
@@ -1,15 +1,7 @@
 import React from 'react';
 import Heroanner1 from '../Components/HeroBanner/Heroanner1';
-import Feature1 from '../Components/Feature/Feature1';
 import Category1 from '../Components/Category/Category1';
 import About1 from '../Components/About/About1';
-import Cta1 from '../Components/Cta/Cta1';
-import Destination1 from '../Components/Destination/Destination1';
-import DealOffers1 from '../Components/DealOffers/DealOffers1';
-import Testimonial1 from '../Components/Testimonial/Testimonial1';
-import Choose1 from '../Components/Choose/Choose1';
-import Team1 from '../Components/Team/Team1';
-import Cta2 from '../Components/Cta/Cta2';
 import Blog1 from '../Components/Blog/Blog1';
 import Brand1 from '../Components/Brand/Brand1';
 
@@ -17,7 +9,7 @@ const Home3 = () => {
     return (
         <div>
             <Heroanner1></Heroanner1>
-            <div style={{ marginTop: '-140px', paddingTop: '140px' }}>
+            <div className="after-hero-offset">
                 <About1></About1>
                 <Category1></Category1>
                 <Blog1></Blog1>

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -10006,3 +10006,8 @@ input.main-search-input::placeholder {
 .hero-1 .hero-content .booking-list-area .booking-list .form .single-select option{
   color: #000;
 }
+
+.after-hero-offset {
+  margin-top: -140px;
+  padding-top: 140px;
+}

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -10008,6 +10008,6 @@ input.main-search-input::placeholder {
 }
 
 .after-hero-offset {
-  margin-top: -140px;
-  padding-top: 140px;
+  margin-top: -146px;
+  padding-top: 146px;
 }


### PR DESCRIPTION
## Summary
- Show a white 1global1.png logo and light navigation links over the hero section
- Swap to the black one-globe.png logo and dark links once the page is scrolled or on other pages
- Offset the post-hero content to avoid header overlap without leaving a white gap

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bea171f8a08330af799b7adde191cb