### PR TITLE
Ensure hero header logo switches permanently after scroll

### DIFF
--- a/src/Components/Header/Header3.jsx
+++ b/src/Components/Header/Header3.jsx
@@ -26,7 +26,7 @@ export default function Header3({ variant }) {
       }
 
       setPrevScrollPos(currentScrollPos);
-      setHasScrolled(currentScrollPos > 0);
+      setHasScrolled((prev) => prev || currentScrollPos > 0);
     };
 
     window.addEventListener('scroll', handleScroll);


### PR DESCRIPTION
## Summary
- Keep hero header logo and text white at first load and switch permanently to dark theme after the user scrolls

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bf080c1cac8330b3827f4a0269b40b