### PR TITLE
Ensure header logo switches after scrolling

### DIFF
--- a/src/Components/Footer/Footer1.jsx
+++ b/src/Components/Footer/Footer1.jsx
@@ -18,7 +18,7 @@ const Footer1 = () => {
         <div className="footer-main">
           {/* Column 1 - Logo + Newsletter */}
           <div className="footer-col">
-            <img src="/1global1.png" alt="1 Global Enterprises Logo" className="footer-logo" />
+            <img src="/one-globe.png" alt="1 Global Enterprises Logo" className="footer-logo" />
             <h3 className="footer-heading">Subscribe Newsletter</h3>
             <p className="footer-subtext">Get our latest deals and updates</p>
             <form className="footer-input" onSubmit={(e) => e.preventDefault()}>

--- a/src/Components/Header/Header3.jsx
+++ b/src/Components/Header/Header3.jsx
@@ -13,6 +13,11 @@ export default function Header3({ variant }) {
   const logoSrc = isHero ? '/1global1.png' : '/one-globe.png';
   const textColor = isHero ? '#fff' : '#000';
 
+  const headerStyle = {
+    color: textColor,
+    backgroundColor: isHero ? 'transparent' : '#fff',
+  };
+
   useEffect(() => {
     const handleScroll = () => {
       const currentScrollPos = window.scrollY;
@@ -26,9 +31,10 @@ export default function Header3({ variant }) {
       }
 
       setPrevScrollPos(currentScrollPos);
-      setHasScrolled((prev) => prev || currentScrollPos > 0);
+      setHasScrolled(currentScrollPos > 0);
     };
 
+    handleScroll();
     window.addEventListener('scroll', handleScroll);
     return () => {
       window.removeEventListener('scroll', handleScroll);
@@ -59,9 +65,9 @@ export default function Header3({ variant }) {
       `}</style>
 
       <header
-        style={{ color: textColor }}
+        style={headerStyle}
         className={`cs_site_header header_style_2 header_style_2_2 cs_style_1 header_sticky_style1 ${
-          variant ? variant : ''
+          isHero ? variant : ''
         } cs_sticky_header cs_site_header_full_width ${
           mobileToggle ? 'cs_mobile_toggle_active' : ''
         } ${isSticky ? isSticky : ''}`}


### PR DESCRIPTION
## Summary
- Switch to black `one-global.png` logo once the user scrolls
- Restore white `1global1.png` logo and transparent header when scrolled back to top

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfcec8d2088330b39e2587dc56c9d6