### PR TITLE
Replace core industries slider with cards and add industry pages

### DIFF
--- a/src/Components/Category/Category1.jsx
+++ b/src/Components/Category/Category1.jsx
@@ -1,86 +1,56 @@
 import React from 'react';
 import { Link } from 'react-router';
-import Slider from 'react-slick';
 
 const Category1 = () => {
+  const categoryContent = [
+    { img: '/shipping.png', title: 'Shipping', link: '/shipping' },
+    { img: '/logistics.png', title: 'Logistics', link: '/logistics' },
+    {
+      img: '/product.png',
+      title: 'Product Distribution',
+      link: '/product-distribution',
+    },
+    {
+      img: '/software.png',
+      title: 'Software Development',
+      link: '/software-development',
+    },
+    {
+      img: '/renewable.png',
+      title: 'Renewable Energy',
+      link: '/renewable-energy',
+    },
+  ];
 
-    const settings = {
-        dots: false,
-        infinite: true,
-        speed: 2000,
-        slidesToShow: 5,
-        slidesToScroll: 1,
-        arrows: false,
-        swipeToSlide: true,
-        autoplay: true,
-        autoplaySpeed: 4000,        
-        responsive: [
-          {
-            breakpoint: 1399,
-            settings: {
-              slidesToShow: 5,
-            }
-          },
-          {
-            breakpoint: 1199,
-            settings: {
-              slidesToShow: 4,
-            }
-          },{
-            breakpoint: 575,
-            settings: {
-              slidesToShow: 1,
-            }
-          }
-        ]
-      };  
-
-      const categoryContent = [
-        {img:'/shipping.png', title:'Shipping'},      
-        {img:'/logistics.png', title:'Logistics'},      
-        {img:'/product.png', title:'Product Distribution'},      
-        {img:'/software.png', title:'Software Development'},      
-        {img:'/renewable.png', title:'Renewable Energy'},      
-      ]; 
-
-    return (
-        <section className="destination-category-section pt-10 pb-4">
-            <div className="plane-shape float-bob-y"></div>
-            <div className="container">
-                <div className="section-title text-center">
-                    <span className="sub-title wow fadeInUp"></span>
-                    <h2 className="wow fadeInUp wow" data-wow-delay=".2s">
-                        Our Core Industries
-                    </h2>
+  return (
+    <section className="destination-category-section pt-10 pb-4">
+      <div className="plane-shape float-bob-y"></div>
+      <div className="container">
+        <div className="section-title text-center">
+          <span className="sub-title wow fadeInUp"></span>
+          <h2 className="wow fadeInUp wow" data-wow-delay=".2s">
+            Our Core Industries
+          </h2>
+        </div>
+      </div>
+      <div className="container">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-6">
+          {categoryContent.map((item, i) => (
+            <div key={i} className="destination-category-item">
+              <div className="category-image">
+                <img src={item.img} alt="img" />
+                <div className="category-content">
+                  <h5>
+                    <Link to={item.link}>{item.title}</Link>
+                  </h5>
                 </div>
+              </div>
             </div>
-            <div className="container-fluid">
-                <div className="swiper category-slider">
-                    <div className="swiper-wrapper cs_slider_gap_301">
-                        <Slider {...settings}>
-                            {categoryContent.map((item, i) => (
-                                <div key={i} className="swiper-slide">
-                                    <div className="destination-category-item">
-                                        <div className="category-image">
-                                            <img src={item.img} alt="img" />
-                                            <div className="category-content">
-                                                <h5>
-                                                    <Link to="/">{item.title}</Link>
-                                                </h5>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            ))}
-                        </Slider>
-                    </div>
-                </div>
-                <div className="swiper-dot4 mt-5">
-                    <div className="dot"></div>
-                </div>
-            </div>
-        </section> 
-    );
+          ))}
+        </div>
+      </div>
+    </section>
+  );
 };
 
 export default Category1;

--- a/src/Pages/LogisticsPage.jsx
+++ b/src/Pages/LogisticsPage.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import BreadCumb from '../Components/Common/BreadCumb';
+
+const LogisticsPage = () => {
+  return (
+    <div>
+      <BreadCumb bgimg="/aboutbg.png" Title="Logistics" />
+      <section className="py-5">
+        <div className="container">
+          <img src="/logistics.png" alt="Logistics" className="mb-4 w-100" />
+          <p>
+            Efficient logistics are essential for keeping supply chains running
+            smoothly. Our logistics team coordinates transportation, warehousing, and
+            distribution to provide a seamless experience from origin to destination.
+          </p>
+          <p>
+            With a network that spans the globe, we offer customized solutions for
+            businesses of all sizes. Advanced tracking systems give our clients
+            real-time visibility, ensuring every shipment is accounted for at every
+            step.
+          </p>
+          <p>
+            Whether by land, sea, or air, our logistics services are designed to
+            maximize speed and minimize cost. We continually refine our operations to
+            meet the evolving needs of modern commerce.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default LogisticsPage;

--- a/src/Pages/ProductDistributionPage.jsx
+++ b/src/Pages/ProductDistributionPage.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import BreadCumb from '../Components/Common/BreadCumb';
+
+const ProductDistributionPage = () => {
+  return (
+    <div>
+      <BreadCumb bgimg="/aboutbg.png" Title="Product Distribution" />
+      <section className="py-5">
+        <div className="container">
+          <img src="/product.png" alt="Product Distribution" className="mb-4 w-100" />
+          <p>
+            Our product distribution services bridge the gap between manufacturers and
+            consumers. We manage every stage of the distribution process, ensuring that
+            products arrive in stores and homes exactly when they are needed.
+          </p>
+          <p>
+            Utilizing strategic partnerships and advanced inventory systems, we are
+            able to handle high volumes without sacrificing accuracy. Our teams monitor
+            performance metrics closely to maintain the highest levels of service.
+          </p>
+          <p>
+            From regional deliveries to international fulfillment, our distribution
+            network is built for scalability. We adapt quickly to market changes,
+            helping our clients expand their reach with confidence.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default ProductDistributionPage;

--- a/src/Pages/RenewableEnergyPage.jsx
+++ b/src/Pages/RenewableEnergyPage.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import BreadCumb from '../Components/Common/BreadCumb';
+
+const RenewableEnergyPage = () => {
+  return (
+    <div>
+      <BreadCumb bgimg="/aboutbg.png" Title="Renewable Energy" />
+      <section className="py-5">
+        <div className="container">
+          <img src="/renewable.png" alt="Renewable Energy" className="mb-4 w-100" />
+          <p>
+            Renewable energy is central to a sustainable future. Our projects harness
+            the power of wind, sun, and water to generate clean electricity and reduce
+            dependence on fossil fuels.
+          </p>
+          <p>
+            We collaborate with communities and governments to develop energy
+            solutions that are both economically and environmentally sound. Each
+            installation is designed to maximize efficiency and minimize ecological
+            impact.
+          </p>
+          <p>
+            Through continued research and investment, we aim to expand the reach of
+            renewable technologies. Our commitment to green energy is helping to build
+            a more resilient and responsible world.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default RenewableEnergyPage;

--- a/src/Pages/ShippingPage.jsx
+++ b/src/Pages/ShippingPage.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import BreadCumb from '../Components/Common/BreadCumb';
+
+const ShippingPage = () => {
+  return (
+    <div>
+      <BreadCumb bgimg="/aboutbg.png" Title="Shipping" />
+      <section className="py-5">
+        <div className="container">
+          <img src="/shipping.png" alt="Shipping" className="mb-4 w-100" />
+          <p>
+            Shipping is the backbone of global trade, moving goods across oceans and
+            connecting markets on every continent. Our shipping services are built on
+            reliability and efficiency, ensuring products reach their destinations on
+            time and in perfect condition.
+          </p>
+          <p>
+            From cargo management to route optimization, we leverage industry-leading
+            technology to provide end-to-end solutions. Our fleet operates under the
+            highest safety standards, and our experienced crews navigate the world's
+            busiest ports with precision.
+          </p>
+          <p>
+            We are committed to sustainability, investing in cleaner fuels and modern
+            vessels that reduce emissions. As global demand continues to grow, our
+            shipping division remains dedicated to delivering exceptional service
+            while minimizing environmental impact.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default ShippingPage;

--- a/src/Pages/SoftwareDevelopmentPage.jsx
+++ b/src/Pages/SoftwareDevelopmentPage.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import BreadCumb from '../Components/Common/BreadCumb';
+
+const SoftwareDevelopmentPage = () => {
+  return (
+    <div>
+      <BreadCumb bgimg="/aboutbg.png" Title="Software Development" />
+      <section className="py-5">
+        <div className="container">
+          <img src="/software.png" alt="Software Development" className="mb-4 w-100" />
+          <p>
+            Our software development team creates innovative solutions that drive
+            digital transformation. From web applications to complex enterprise
+            systems, we build scalable products tailored to our clients' needs.
+          </p>
+          <p>
+            We follow modern development practices and emphasize collaboration,
+            ensuring every project meets rigorous quality standards. Our developers are
+            fluent in a variety of technologies, enabling rapid prototyping and
+            reliable deployment.
+          </p>
+          <p>
+            Beyond delivery, we provide ongoing support and optimization to keep
+            software running smoothly. Our goal is to empower businesses with tools
+            that enhance productivity and unlock new opportunities.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default SoftwareDevelopmentPage;

--- a/src/Routes/Routes.jsx
+++ b/src/Routes/Routes.jsx
@@ -15,6 +15,11 @@ import BlogGrid from "../Pages/BlogGrid";
 import BlogDetailsPage from "../Pages/BlogDetailsPage";
 import BlogSidebarPage from "../Pages/BlogSidebarPage";
 import InvestorRelationsPage from "../Pages/InvestorRelationsPage";
+import ShippingPage from "../Pages/ShippingPage";
+import LogisticsPage from "../Pages/LogisticsPage";
+import ProductDistributionPage from "../Pages/ProductDistributionPage";
+import SoftwareDevelopmentPage from "../Pages/SoftwareDevelopmentPage";
+import RenewableEnergyPage from "../Pages/RenewableEnergyPage";
 
 export const router = createBrowserRouter([
   {
@@ -68,6 +73,26 @@ export const router = createBrowserRouter([
       {
         path: "investor-relations",
         Component: InvestorRelationsPage,
+      },
+      {
+        path: "shipping",
+        Component: ShippingPage,
+      },
+      {
+        path: "logistics",
+        Component: LogisticsPage,
+      },
+      {
+        path: "product-distribution",
+        Component: ProductDistributionPage,
+      },
+      {
+        path: "software-development",
+        Component: SoftwareDevelopmentPage,
+      },
+      {
+        path: "renewable-energy",
+        Component: RenewableEnergyPage,
       },
       {
         path: "blog",


### PR DESCRIPTION
## Summary
- Replace core industries slider with static card grid linking to dedicated industry pages
- Add new pages for Shipping, Logistics, Product Distribution, Software Development, and Renewable Energy
- Wire new industry pages into application routing

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfd9a3f5848330a10a51514760672e