### PR TITLE
Add corporate sustainability page and scroll reset on navigation

### DIFF
--- a/src/Components/Footer/Footer1.jsx
+++ b/src/Components/Footer/Footer1.jsx
@@ -43,8 +43,9 @@ const Footer1 = () => {
               <li><Link to="/">Home</Link></li>
               <li><Link to="/about">About Us</Link></li>
               <li><Link to="/activities">Activities</Link></li>
-              <li><Link to="/team">Our Team</Link></li>
-              <li><Link to="/blog">Blog</Link></li>
+                <li><Link to="/team">Our Team</Link></li>
+                <li><Link to="/corporate-sustainability">Corporate Sustainability</Link></li>
+                <li><Link to="/blog">Blog</Link></li>
               <li><Link to="/contact">Contact</Link></li>
             </ul>
           </div>

--- a/src/Components/Header/Nav.jsx
+++ b/src/Components/Header/Nav.jsx
@@ -15,11 +15,17 @@ export default function Nav({ setMobileToggle, linkColor }) {
       </li>
 
 
-      <li>
-        <Link to="/activities" onClick={() => setMobileToggle(false)} style={{ color: linkColor }}>
-        Activities
-        </Link>
-      </li>
+        <li>
+          <Link to="/activities" onClick={() => setMobileToggle(false)} style={{ color: linkColor }}>
+          Activities
+          </Link>
+        </li>
+
+        <li>
+          <Link to="/corporate-sustainability" onClick={() => setMobileToggle(false)} style={{ color: linkColor }}>
+          Corporate Sustainability
+          </Link>
+        </li>
 
       <li>
         <Link to="/team" style={{ color: linkColor }}>Our Team</Link>

--- a/src/Layout/Main.jsx
+++ b/src/Layout/Main.jsx
@@ -1,10 +1,16 @@
 import { Outlet, useLocation } from "react-router";
+import { useEffect } from "react";
 import Header3 from "../Components/Header/Header3";
 import Footer1 from "../Components/Footer/Footer1";
 
 const Main = () => {
     const location = useLocation();
     const isHome = location.pathname === "/";
+
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, [location.pathname]);
+
     return (
         <div className='main-page-area'>
             {!isHome && <Header3></Header3>}

--- a/src/Pages/CorporateSustainabilityPage.jsx
+++ b/src/Pages/CorporateSustainabilityPage.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import BreadCumb from '../Components/Common/BreadCumb';
+
+const CorporateSustainabilityPage = () => {
+  return (
+    <div>
+      <BreadCumb bgimg="/aboutbg.png" Title="Corporate Sustainability" />
+      <section className="py-5">
+        <div className="container">
+          <div className="row align-items-center mb-5">
+            <div className="col-md-6">
+              <img src="/renewable.png" alt="Wind turbines and solar panels" className="img-fluid rounded" />
+            </div>
+            <div className="col-md-6">
+              <h2>Building a Greener Future</h2>
+              <p>
+                At 1 Global Enterprises, sustainability is woven into every aspect of our business. We invest in renewable
+                energy, reduce waste across our operations, and collaborate with partners who share our vision for a cleaner
+                planet.
+              </p>
+              <p>
+                Our initiatives include energy-efficient logistics, responsible sourcing, and support for community
+                environmental programs. Together, these efforts help us minimize our footprint and create lasting value for
+                future generations.
+              </p>
+            </div>
+          </div>
+          <div className="row">
+            <div className="col-md-6 order-md-2">
+              <img src="/about4.png" alt="Team planting trees" className="img-fluid rounded" />
+            </div>
+            <div className="col-md-6 order-md-1">
+              <h3>People and Planet</h3>
+              <p>
+                We believe that thriving communities and a healthy environment go hand in hand. Our corporate sustainability
+                program empowers employees to volunteer, promotes diversity and inclusion, and ensures that growth never comes
+                at the expense of the planet.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default CorporateSustainabilityPage;

--- a/src/Routes/Routes.jsx
+++ b/src/Routes/Routes.jsx
@@ -20,6 +20,7 @@ import LogisticsPage from "../Pages/LogisticsPage";
 import ProductDistributionPage from "../Pages/ProductDistributionPage";
 import SoftwareDevelopmentPage from "../Pages/SoftwareDevelopmentPage";
 import RenewableEnergyPage from "../Pages/RenewableEnergyPage";
+import CorporateSustainabilityPage from "../Pages/CorporateSustainabilityPage";
 
 export const router = createBrowserRouter([
   {
@@ -90,10 +91,14 @@ export const router = createBrowserRouter([
         path: "software-development",
         Component: SoftwareDevelopmentPage,
       },
-      {
-        path: "renewable-energy",
-        Component: RenewableEnergyPage,
-      },
+        {
+          path: "renewable-energy",
+          Component: RenewableEnergyPage,
+        },
+        {
+          path: "corporate-sustainability",
+          Component: CorporateSustainabilityPage,
+        },
       {
         path: "blog",
         Component: BlogGrid,


### PR DESCRIPTION
## Summary
- Reset scroll position on route changes
- Add Corporate Sustainability page with content and images
- Link Corporate Sustainability page in router, header, and footer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfddc227a0833084d38c2c512a0768