### PR TITLE
feat: show categories without slider

### DIFF
--- a/src/Components/Category/Category1.jsx
+++ b/src/Components/Category/Category1.jsx
@@ -1,47 +1,15 @@
 import React from 'react';
 import { Link } from 'react-router';
-import Slider from 'react-slick';
 
 const Category1 = () => {
 
-    const settings = {
-        dots: false,
-        infinite: true,
-        speed: 2000,
-        slidesToShow: 5,
-        slidesToScroll: 1,
-        arrows: false,
-        swipeToSlide: true,
-        autoplay: true,
-        autoplaySpeed: 4000,        
-        responsive: [
-          {
-            breakpoint: 1399,
-            settings: {
-              slidesToShow: 5,
-            }
-          },
-          {
-            breakpoint: 1199,
-            settings: {
-              slidesToShow: 4,
-            }
-          },{
-            breakpoint: 575,
-            settings: {
-              slidesToShow: 1,
-            }
-          }
-        ]
-      };  
-
-      const categoryContent = [
-        {img:'/shipping.png', title:'Shipping'},      
-        {img:'/logistics.png', title:'Logistics'},      
-        {img:'/product.png', title:'Product Distribution'},      
-        {img:'/software.png', title:'Software Development'},      
-        {img:'/renewable.png', title:'Renewable Energy'},      
-      ]; 
+    const categoryContent = [
+        {img:'/shipping.png', title:'Shipping', path:'/shipping'},
+        {img:'/logistics.png', title:'Logistics', path:'/logistics'},
+        {img:'/product.png', title:'Product Distribution', path:'/product-distribution'},
+        {img:'/software.png', title:'Software Development', path:'/software-development'},
+        {img:'/renewable.png', title:'Renewable Energy', path:'/renewable-energy'},
+      ];
 
     return (
         <section className="destination-category-section pt-10 pb-4">
@@ -55,28 +23,21 @@ const Category1 = () => {
                 </div>
             </div>
             <div className="container-fluid">
-                <div className="swiper category-slider">
-                    <div className="swiper-wrapper cs_slider_gap_301">
-                        <Slider {...settings}>
-                            {categoryContent.map((item, i) => (
-                                <div key={i} className="swiper-slide">
-                                    <div className="destination-category-item">
-                                        <div className="category-image">
-                                            <img src={item.img} alt="img" />
-                                            <div className="category-content">
-                                                <h5>
-                                                    <Link to="/">{item.title}</Link>
-                                                </h5>
-                                            </div>
-                                        </div>
+                <div className="row g-4 justify-content-center">
+                    {categoryContent.map((item, i) => (
+                        <div key={i} className="col-auto">
+                            <div className="destination-category-item">
+                                <div className="category-image">
+                                    <img src={item.img} alt={item.title} />
+                                    <div className="category-content">
+                                        <h5>
+                                            <Link to={item.path}>{item.title}</Link>
+                                        </h5>
                                     </div>
                                 </div>
-                            ))}
-                        </Slider>
-                    </div>
-                </div>
-                <div className="swiper-dot4 mt-5">
-                    <div className="dot"></div>
+                            </div>
+                        </div>
+                    ))}
                 </div>
             </div>
         </section> 


### PR DESCRIPTION
## Summary
- Replace Category1 slider with static grid
- Link each category card to its dedicated page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bff305dff4833093574108700ac300