### PR TITLE
Create global presence page with map and location sidebar

### DIFF
--- a/src/Components/GlobalPresence/ContactMapContainer.jsx
+++ b/src/Components/GlobalPresence/ContactMapContainer.jsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react";
+import { RefreshCw, Maximize2, Minimize2 } from "lucide-react";
+
+const MAP_BASE_URL =
+  "https://www.google.com/maps/d/u/0/embed?mid=1rF5337I7j7xk98at6ZPdMul4aglzrLg&hl=en&ehbc=2E312F";
+
+const ContactMapContainer = ({
+  coordinates,
+  selectedCity,
+}) => {
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [isFullScreen, setIsFullScreen] = useState(false);
+  const [mapVersion, setMapVersion] = useState(0);
+
+  const { lat, lng, zoom } = coordinates;
+
+  useEffect(() => {
+    setIsLoaded(false);
+    setMapVersion((prev) => prev + 1);
+  }, [lat, lng, zoom]);
+
+  const mapUrl = `${MAP_BASE_URL}&z=${zoom}&ll=${lat},${lng}`;
+
+  const handleReload = () => {
+    setIsLoaded(false);
+    setMapVersion((prev) => prev + 1);
+  };
+
+  return (
+    <div className={`global-map-card${isFullScreen ? " fullscreen" : ""}`}>
+      <div className="global-map-header">
+        <div>
+          <h3>Interactive Global Presence Map</h3>
+          {selectedCity && (
+            <p>
+              Viewing: <span>{selectedCity.name}</span>
+            </p>
+          )}
+        </div>
+        <div className="global-map-actions">
+          <button type="button" onClick={handleReload} aria-label="Reload map">
+            <RefreshCw size={16} />
+            <span>Refresh</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => setIsFullScreen((prev) => !prev)}
+            aria-label={isFullScreen ? "Exit full screen" : "Enter full screen"}
+          >
+            {isFullScreen ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
+            <span>{isFullScreen ? "Compact" : "Expand"}</span>
+          </button>
+        </div>
+      </div>
+      <div className="global-map-frame">
+        {!isLoaded && (
+          <div className="global-map-loading">
+            <div className="spinner" />
+            <p>Loading map...</p>
+          </div>
+        )}
+        <iframe
+          key={mapVersion}
+          src={mapUrl}
+          title="Interactive Map"
+          allowFullScreen
+          loading="lazy"
+          onLoad={() => setIsLoaded(true)}
+        />
+      </div>
+      <div className="global-map-footer">
+        <p>© 2025 OECL Global Presence Map — Data updated quarterly</p>
+      </div>
+    </div>
+  );
+};
+
+export default ContactMapContainer;

--- a/src/Components/GlobalPresence/ContactSidebar.jsx
+++ b/src/Components/GlobalPresence/ContactSidebar.jsx
@@ -1,0 +1,111 @@
+import { useMemo } from "react";
+import { MapPin, Phone, Mail, Home, ChevronRight, Globe } from "lucide-react";
+
+const formatContacts = (contacts = []) =>
+  contacts.filter(Boolean).join(" \u2022 ");
+
+const ContactSidebar = ({
+  countries,
+  expandedCountry,
+  onToggleCountry,
+  onSelectCity,
+  selectedCity,
+  selectedCountryCode,
+}) => {
+  const selectedCityKey = selectedCity ? `${selectedCity.name}-${selectedCity.lat}-${selectedCity.lng}` : "";
+
+  const emptyState = useMemo(
+    () => !countries || countries.length === 0,
+    [countries]
+  );
+
+  if (emptyState) {
+    return (
+      <div className="global-sidebar-card">
+        <div className="global-sidebar-header">
+          <Globe size={18} />
+          <h3>Global Locations</h3>
+        </div>
+        <div className="global-sidebar-empty">
+          <p>Location data is currently unavailable. Please try again later.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="global-sidebar-card">
+      <div className="global-sidebar-header">
+        <Globe size={18} />
+        <h3>Global Locations</h3>
+      </div>
+      <div className="global-sidebar-content">
+        {countries.map((country) => {
+          const isExpanded = expandedCountry === country.code;
+          const isSelectedCountry = selectedCountryCode === country.code;
+
+          return (
+            <div className="global-country" key={country.code}>
+              <button
+                type="button"
+                className={`global-country-trigger${
+                  isExpanded ? " expanded" : ""
+                }${isSelectedCountry ? " is-selected" : ""}`}
+                onClick={() => onToggleCountry(country.code)}
+              >
+                <span className="global-country-name">{country.name}</span>
+                <ChevronRight className="global-country-icon" size={18} />
+              </button>
+              {isExpanded && (
+                <div className="global-city-list">
+                  {country.cities.map((city) => {
+                    const cityKey = `${city.name}-${city.lat}-${city.lng}`;
+                    const isActive = cityKey === selectedCityKey;
+                    return (
+                      <div className="global-city-item" key={cityKey}>
+                        <button
+                          type="button"
+                          className={`global-city-button${
+                            isActive ? " active" : ""
+                          }`}
+                          onClick={() => onSelectCity(country.code, city)}
+                        >
+                          <MapPin size={16} />
+                          <span>{city.name}</span>
+                        </button>
+                        {isActive && (
+                          <div className="global-city-details">
+                            {city.address && (
+                              <div className="global-city-detail-row">
+                                <Home size={16} />
+                                <p>{city.address}</p>
+                              </div>
+                            )}
+                            {city.contacts && city.contacts.length > 0 && (
+                              <div className="global-city-detail-row">
+                                <Phone size={16} />
+                                <p>{formatContacts(city.contacts)}</p>
+                              </div>
+                            )}
+                            {city.email && (
+                              <div className="global-city-detail-row">
+                                <Mail size={16} />
+                                <a href={`mailto:${city.email}`}>{city.email}</a>
+                              </div>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default ContactSidebar;

--- a/src/Components/GlobalPresence/countriesData.js
+++ b/src/Components/GlobalPresence/countriesData.js
@@ -1,0 +1,390 @@
+export const COUNTRIES = [
+  {
+    code: "in",
+    name: "India",
+    lat: 19.1061,
+    lng: 72.883,
+    cities: [
+      {
+        name: "Mumbai",
+        lat: 19.1061,
+        lng: 72.883,
+        address:
+          "Town Center - 2, Office No. 607, 6th Floor, Marol, Andheri Kurla Road, Andheri East, Mumbai - 400059.",
+        contacts: ["+91 8879756838", "022-35131688", "35113475", "35082586"],
+        email: "info@oecl.sg",
+      },
+      {
+        name: "Delhi",
+        lat: 28.5894,
+        lng: 77.0318,
+        address:
+          "Plot No. 15, 1st Floor, Block C, Pocket 8, Sector 17, Dwarka, New Delhi 110075",
+        contacts: ["+91 11 41088871"],
+        email: "info@oecl.sg",
+      },
+      {
+        name: "Chennai Warehouse",
+        lat: 13.0231,
+        lng: 79.9632,
+        address:
+          "Survey No. 209/6A(Part) 209/6B(Part), Mannur & Valarpuram Village, Perambakkam Road, Sriperumbudur Taluk, Kanchipuram District - 602105",
+        contacts: ["+91 9994355523"],
+        email: "info@oecl.sg",
+      },
+      {
+        name: "Chennai",
+        lat: 13.0068,
+        lng: 80.2048,
+        address: "Roma Building, Door No. 10, 3rd Floor, G.S.T. Road, Alandur, Chennai - 600 016",
+        contacts: ["044 4689 4646"],
+        email: "info@oecl.sg",
+      },
+      {
+        name: "Kerala",
+        lat: 9.9323,
+        lng: 76.2996,
+        address:
+          "CC 59/801A Elizabeth Memorial Building, Thevara Ferry Jn, Cochin 682013, Kerala",
+        contacts: ["+91 484 4019192", "+91 484 4019193"],
+        email: "info@oecl.sg",
+      },
+      {
+        name: "Hyderabad",
+        lat: 17.4425,
+        lng: 78.4735,
+        address:
+          "H.No. 1-8-450/1/A-7 Indian Airlines Colony, Opp Police Lines, Begumpet Hyderabad - 500016, Telangana",
+        contacts: ["040-49559704"],
+        email: "info@oecl.sg",
+      },
+      {
+        name: "Bangalore",
+        lat: 13.0185,
+        lng: 77.6419,
+        address:
+          "3C-964 IIIrd Cross Street, HRBR Layout 1st Block, Kalyan Nagar Banaswadi, Bengaluru - 560043",
+        contacts: ["+91 9841676259"],
+        email: "info@oecl.sg",
+      },
+      {
+        name: "Kolkata",
+        lat: 22.5745,
+        lng: 88.4353,
+        address:
+          "Imagine Techpark, Unit No. 10, 19th Floor, Block DN 6, Sector V Salt Lake City, Kolkata, West Bengal, India - 700091",
+        contacts: ["+91 33 4814 9162", "+91 33 4814 9163"],
+        email: "info@oecl.sg",
+      },
+    ],
+  },
+  {
+    code: "my",
+    name: "Malaysia",
+    lat: 1.4842,
+    lng: 103.7629,
+    cities: [
+      {
+        name: "Pasir Gudang",
+        lat: 1.4842,
+        lng: 103.7629,
+        address:
+          "Unit 20-03A, Level 20 Menara Zurich, 15 Jalan Dato Abdullah Tahir, 80300 Johor Bahru",
+        contacts: ["+603-3319 2778", "+603-3319 2774", "+603-3319 2775", "+603-3319 2779"],
+        email: "info@oecl.sg",
+      },
+      {
+        name: "Port Klang",
+        lat: 2.9982,
+        lng: 101.3831,
+        address:
+          "MTBBT 2, 3A-5, Jalan Batu Nilam 16, The Landmark (Behind AEON Mall), Bandar Bukit Tinggi 2, 41200 Klang, Selangor",
+        contacts: ["+603-3319 2778", "+603-3319 2774", "+603-3319 2775"],
+        email: "info@oecl.sg",
+      },
+    ],
+  },
+  {
+    code: "ae",
+    name: "United Arab Emirates",
+    lat: 25.2048,
+    lng: 55.2708,
+    cities: [
+      {
+        name: "Dubai",
+        lat: 25.2048,
+        lng: 55.2708,
+        address: "Office # 509, Al Nazar Plaza, Oud Metha, Dubai, U.A.E",
+        contacts: ["+971 4 343 3388"],
+      },
+      {
+        name: "Jebel Ali",
+        lat: 24.9857,
+        lng: 55.1436,
+        address:
+          "Warehouse # ZG06, Near Roundabout 13, North Zone, P.O. Box 30821, Jebel Ali, Dubai, U.A.E",
+        contacts: ["+971 4 881 9787"],
+      },
+      {
+        name: "Abu Dhabi",
+        lat: 24.4539,
+        lng: 54.3773,
+        address:
+          "P.O. Box 30500, Office 3-1, Unit 101, 1st Floor, Al Jaber Jewellery Building, Al Khalidiya, Abu Dhabi, U.A.E",
+        contacts: ["+971 50 433 7214"],
+      },
+    ],
+  },
+  {
+    code: "qa",
+    name: "Qatar",
+    lat: 25.276987,
+    lng: 51.520008,
+    cities: [
+      {
+        name: "Doha",
+        lat: 25.276987,
+        lng: 51.520008,
+        address: "Office No. 48, 2nd Floor, Al Matar Centre, Old Airport Road, Doha",
+        contacts: ["0974 33622555"],
+      },
+    ],
+  },
+  {
+    code: "cn",
+    name: "China",
+    lat: 22.54262,
+    lng: 114.11696,
+    cities: [
+      {
+        name: "Shenzhen",
+        lat: 22.54262,
+        lng: 114.11696,
+        address:
+          "13C02, Block A, Zhaoxin Huijin Plaza, 3085 Shennan East Road, Luohu, Shenzhen",
+        contacts: ["+86 755 8222 2447"],
+        email: "helen@haixun.co",
+      },
+    ],
+  },
+  {
+    code: "sa",
+    name: "Saudi Arabia",
+    lat: 26.4207,
+    lng: 50.0888,
+    cities: [
+      {
+        name: "Dammam",
+        lat: 26.4207,
+        lng: 50.0888,
+        address:
+          "Building No. 2817, Secondary No. 9403, King Faisal Road, Al Tubebayshi Dist, Dammam, KSA 32233",
+        contacts: ["+966 13 343 0003"],
+      },
+      {
+        name: "Riyadh",
+        lat: 24.7136,
+        lng: 46.6753,
+        address:
+          "Room No. T18, Rail Business Centre, Bldg No. 3823, Omar Aimukhtar St, Thulaim, Riyadh 11332",
+        contacts: ["+966 11 295 0020"],
+      },
+      {
+        name: "Jeddah",
+        lat: 21.4858,
+        lng: 39.1925,
+        address:
+          "Al-Madinah Al-Munawarah Road, Al Sharafeyah, Jeddah 4542-22234, Kingdom of Saudi Arabia",
+        contacts: ["+966 12 578 0874"],
+      },
+    ],
+  },
+  {
+    code: "sg",
+    name: "Singapore",
+    lat: 1.3521,
+    lng: 103.8198,
+    cities: [
+      {
+        name: "Singapore",
+        lat: 1.3521,
+        lng: 103.8198,
+        address:
+          "Blk 511 Kampong Bahru Road, #03-01 Keppel Distripark, Singapore - 099447",
+        contacts: ["+65 6908 0838"],
+        email: "info@oecl.sg",
+      },
+    ],
+  },
+  {
+    code: "id",
+    name: "Indonesia",
+    lat: -6.2088,
+    lng: 106.8456,
+    cities: [
+      {
+        name: "Jakarta",
+        lat: -6.2088,
+        lng: 106.8456,
+        address:
+          "408, Lina Building, JL. HR Rasuna Said Kav B7, Jakarta",
+        contacts: ["+62 21 529 20292", "+62 21 522 4887"],
+        email: "logistics.jkt@oecl.sg",
+      },
+      {
+        name: "Surabaya",
+        lat: -7.2575,
+        lng: 112.7521,
+        address:
+          "Japfa Indoland Center, Japfa Tower 1, Lantai 4/401-A JL Jend, Basuki Rahmat 129-137, Surabaya 60271",
+        contacts: ["+62 21 529 20292", "+62 21 522 4887"],
+        email: "logistics.jkt@oecl.sg",
+      },
+    ],
+  },
+  {
+    code: "lk",
+    name: "Sri Lanka",
+    lat: 6.9271,
+    lng: 79.8612,
+    cities: [
+      {
+        name: "Colombo",
+        lat: 6.9271,
+        lng: 79.8612,
+        address:
+          "Ceylinco House, 9th Floor, No. 69, Janadhipathi Mawatha, Colombo 01, Sri Lanka",
+        contacts: ["+94 114 477 499", "+94 114 477 494", "+94 114 477 498"],
+        email: "info.cmb@globalconsol.com",
+      },
+    ],
+  },
+  {
+    code: "th",
+    name: "Thailand",
+    lat: 13.72957,
+    lng: 100.53095,
+    cities: [
+      {
+        name: "Bangkok",
+        lat: 13.72957,
+        lng: 100.53095,
+        address:
+          "109 CCT Building, 3rd Floor, Room 3, Surawong Road, Suriyawongse, Bangrak, Bangkok 10500",
+        contacts: ["+662-634-3240", "+662-634-3942"],
+        email: "info@oecl.sg",
+      },
+    ],
+  },
+  {
+    code: "mm",
+    name: "Myanmar",
+    lat: 16.8409,
+    lng: 96.1735,
+    cities: [
+      {
+        name: "Yangon",
+        lat: 16.8409,
+        lng: 96.1735,
+        address:
+          "No. 608, Room 8B, Bo Soon Pat Tower, Merchant Street, Pabedan Township, Yangon, Myanmar",
+        contacts: ["+951 243158", "+951 377985", "+951 243101"],
+        email: "info@globalconsol.com",
+      },
+    ],
+  },
+  {
+    code: "pk",
+    name: "Pakistan",
+    lat: 24.8608,
+    lng: 67.0097,
+    cities: [
+      {
+        name: "Karachi",
+        lat: 24.8608,
+        lng: 67.0097,
+        address:
+          "Suite No. 301, 3rd Floor, Fortune Center, Shahrah-e-Faisal, Block 6, PECHS, Karachi, Pakistan",
+        contacts: ["+92-300-8282511", "+92-21-34302281-5"],
+        email: "info.pk@globalconsol.com",
+      },
+      {
+        name: "Lahore",
+        lat: 31.5204,
+        lng: 74.3487,
+        address:
+          "Office #301, 3rd Floor, Gulberg Arcade Main Market, Gulberg 2, Lahore, Pakistan",
+        contacts: ["+92 42-35782306", "+92 42-35782307", "+92 42-35782308"],
+        email: "info.pk@globalconsol.com",
+      },
+    ],
+  },
+  {
+    code: "us",
+    name: "United States",
+    lat: 41.8622,
+    lng: -87.7209,
+    cities: [
+      {
+        name: "Chicago",
+        lat: 41.8622,
+        lng: -87.7209,
+        address: "939 W. North Avenue, Suite 750, Chicago, IL 60642",
+        contacts: ["+1 847 254 7320"],
+        email: "info@gglusa.us",
+      },
+      {
+        name: "New York",
+        lat: 40.533,
+        lng: -74.3481,
+        address:
+          "New Jersey Branch, 33 Wood Avenue South Suite 600, Iselin, NJ 08830",
+        contacts: ["+1 732 456 6780"],
+        email: "info@gglusa.us",
+      },
+      {
+        name: "Los Angeles",
+        lat: 34.0522,
+        lng: -118.2437,
+        address: "2250 South Central Avenue, Compton, CA 90220",
+        contacts: ["+1 310 928 3903"],
+        email: "info@gglusa.us",
+      },
+    ],
+  },
+  {
+    code: "gb",
+    name: "United Kingdom",
+    lat: 51.5074,
+    lng: -0.1278,
+    cities: [
+      {
+        name: "London",
+        lat: 51.5074,
+        lng: -0.1278,
+        address:
+          "167-169 Great Portland Street, 5th Floor, London W1W 5PF, United Kingdom",
+        contacts: ["+44 (0) 203 393 9508"],
+      },
+    ],
+  },
+  {
+    code: "au",
+    name: "Australia",
+    lat: -37.7064,
+    lng: 144.8503,
+    cities: [
+      {
+        name: "Melbourne",
+        lat: -37.7064,
+        lng: 144.8503,
+        address:
+          "Suite 5, 7-9 Mallet Road, Tullamarine, Victoria, 3043",
+        contacts: ["+61 432 254 969", "+61 3 8820 5157"],
+        email: "info@gglaustralia.com",
+      },
+    ],
+  },
+];
+
+export default COUNTRIES;

--- a/src/Components/Header/Nav.jsx
+++ b/src/Components/Header/Nav.jsx
@@ -22,10 +22,14 @@ export default function Nav({ setMobileToggle, linkColor }) {
         </li>
 
       <li>
-          <Link to="/activities" onClick={() => setMobileToggle(false)} style={{ color: linkColor }}>
+        <Link
+          to="/global-presence"
+          onClick={() => setMobileToggle(false)}
+          style={{ color: linkColor }}
+        >
           Global Presence
-          </Link>
-        </li>
+        </Link>
+      </li>
 
 
 

--- a/src/Pages/GlobalPresencePage.jsx
+++ b/src/Pages/GlobalPresencePage.jsx
@@ -1,0 +1,146 @@
+import { useEffect, useMemo, useState } from "react";
+import { useLocation } from "react-router";
+import BreadCumb from "../Components/Common/BreadCumb";
+import ContactMapContainer from "../Components/GlobalPresence/ContactMapContainer";
+import ContactSidebar from "../Components/GlobalPresence/ContactSidebar";
+import { COUNTRIES } from "../Components/GlobalPresence/countriesData";
+import useIsMobile from "../hooks/useIsMobile";
+import "../assets/global-presence.css";
+
+const GlobalPresencePage = () => {
+  const location = useLocation();
+  const isMobile = useIsMobile();
+  const isIndiaPage = useMemo(
+    () => location.pathname.toLowerCase().includes("india"),
+    [location.pathname]
+  );
+
+  const countries = useMemo(() => {
+    const filtered = COUNTRIES.filter(
+      (country) => !(isIndiaPage && country.code === "pk")
+    );
+    return [...filtered].sort((a, b) => a.name.localeCompare(b.name));
+  }, [isIndiaPage]);
+
+  const [expandedCountry, setExpandedCountry] = useState(
+    countries[0]?.code ?? null
+  );
+  const [selectedCountryCode, setSelectedCountryCode] = useState(
+    countries[0]?.code ?? null
+  );
+  const [selectedCity, setSelectedCity] = useState(
+    countries[0]?.cities?.[0] ?? null
+  );
+  const [mobileView, setMobileView] = useState("sidebar");
+
+  useEffect(() => {
+    if (countries.length) {
+      setExpandedCountry(countries[0].code);
+      setSelectedCountryCode(countries[0].code);
+      setSelectedCity(countries[0].cities[0]);
+    }
+  }, [countries]);
+
+  useEffect(() => {
+    if (!isMobile) {
+      setMobileView("combined");
+    } else if (mobileView === "combined") {
+      setMobileView("sidebar");
+    }
+  }, [isMobile, mobileView]);
+
+  const handleToggleCountry = (code) => {
+    setExpandedCountry((prev) => (prev === code ? null : code));
+  };
+
+  const handleSelectCity = (countryCode, city) => {
+    setSelectedCountryCode(countryCode);
+    setSelectedCity(city);
+  };
+
+  const coordinates = useMemo(() => {
+    if (selectedCity) {
+      return {
+        lat: selectedCity.lat,
+        lng: selectedCity.lng,
+        zoom: 11,
+      };
+    }
+    const fallbackCountry = countries.find((item) => item.code === selectedCountryCode);
+    if (fallbackCountry) {
+      return { lat: fallbackCountry.lat, lng: fallbackCountry.lng, zoom: 5 };
+    }
+    return { lat: 1.3521, lng: 103.8198, zoom: 3 };
+  }, [countries, selectedCity, selectedCountryCode]);
+
+  return (
+    <div className="global-presence-page">
+      <BreadCumb
+        bgimg="/assets/img/breadcrumb/breadcrumb.jpg"
+        Title="Global Presence"
+      />
+      <section className="global-presence-hero">
+        <div className="container">
+          <div className="global-presence-intro">
+            <h1>Our Global Network</h1>
+            <p>
+              Explore OECL's expansive international footprint, spanning key
+              logistics hubs across Asia, the Middle East, Europe, Australia,
+              and North America. Select a location to see detailed contact
+              information and discover how our teams can support your supply
+              chain requirements.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {isMobile && (
+        <div className="global-mobile-toggle">
+          <button
+            type="button"
+            className={mobileView === "sidebar" ? "active" : ""}
+            onClick={() => setMobileView("sidebar")}
+          >
+            Locations
+          </button>
+          <button
+            type="button"
+            className={mobileView === "map" ? "active" : ""}
+            onClick={() => setMobileView("map")}
+          >
+            Map
+          </button>
+        </div>
+      )}
+
+      <section className="global-presence-layout">
+        <div
+          className={`global-map-section${
+            isMobile && mobileView !== "map" ? " hidden-mobile" : ""
+          }`}
+        >
+          <ContactMapContainer
+            coordinates={coordinates}
+            selectedCity={selectedCity}
+          />
+        </div>
+        <div
+          className={`global-sidebar-section${
+            isMobile && mobileView !== "sidebar" ? " hidden-mobile" : ""
+          }`}
+        >
+          <ContactSidebar
+            countries={countries}
+            expandedCountry={expandedCountry}
+            onToggleCountry={handleToggleCountry}
+            onSelectCity={handleSelectCity}
+            selectedCity={selectedCity}
+            selectedCountryCode={selectedCountryCode}
+          />
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default GlobalPresencePage;

--- a/src/Routes/Routes.jsx
+++ b/src/Routes/Routes.jsx
@@ -21,6 +21,7 @@ import ProductDistributionPage from "../Pages/ProductDistributionPage";
 import SoftwareDevelopmentPage from "../Pages/SoftwareDevelopmentPage";
 import RenewableEnergyPage from "../Pages/RenewableEnergyPage";
 import CorporateSustainabilityPage from "../Pages/CorporateSustainabilityPage";
+import GlobalPresencePage from "../Pages/GlobalPresencePage";
 
 export const router = createBrowserRouter([
   {
@@ -54,6 +55,10 @@ export const router = createBrowserRouter([
       {
         path: "activities",
         Component: ActivitiesPage,
+      },
+      {
+        path: "global-presence",
+        Component: GlobalPresencePage,
       },
       {
         path: "activities/activities-details",

--- a/src/assets/global-presence.css
+++ b/src/assets/global-presence.css
@@ -1,0 +1,374 @@
+.global-presence-page {
+  background: linear-gradient(180deg, #fdf9f0 0%, #ffffff 100%);
+  padding-bottom: 80px;
+}
+
+.global-presence-hero {
+  padding: 80px 0 40px;
+}
+
+.global-presence-intro {
+  max-width: 780px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.global-presence-intro h1 {
+  font-size: 42px;
+  font-weight: 700;
+  color: #102a43;
+  margin-bottom: 16px;
+}
+
+.global-presence-intro p {
+  font-size: 18px;
+  line-height: 1.8;
+  color: #4f5d75;
+}
+
+.global-mobile-toggle {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  margin: 0 auto 24px;
+  width: 100%;
+}
+
+.global-mobile-toggle button {
+  border: 1px solid #d4d9df;
+  background: #ffffff;
+  color: #344054;
+  border-radius: 999px;
+  padding: 10px 28px;
+  font-weight: 600;
+  transition: all 0.3s ease;
+}
+
+.global-mobile-toggle button.active,
+.global-mobile-toggle button:hover {
+  background: #f97316;
+  border-color: #f97316;
+  color: #ffffff;
+}
+
+.global-presence-layout {
+  display: flex;
+  align-items: stretch;
+  gap: 32px;
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.global-map-section {
+  flex: 1;
+  min-height: 520px;
+}
+
+.global-sidebar-section {
+  width: 420px;
+  flex-shrink: 0;
+}
+
+.global-map-card,
+.global-sidebar-card {
+  background: #ffffff;
+  border-radius: 24px;
+  box-shadow: 0 24px 60px rgba(15, 32, 60, 0.08);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.global-map-card.fullscreen {
+  position: relative;
+  width: 100%;
+}
+
+.global-map-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 24px;
+  border-bottom: 1px solid #f1f5f9;
+  background: linear-gradient(90deg, rgba(255, 237, 213, 0.6), rgba(255, 255, 255, 0.9));
+}
+
+.global-map-header h3 {
+  font-size: 20px;
+  font-weight: 700;
+  color: #c2410c;
+  margin: 0;
+}
+
+.global-map-header p {
+  margin: 4px 0 0;
+  color: #475569;
+  font-size: 14px;
+}
+
+.global-map-header span {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.global-map-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.global-map-actions button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-radius: 999px;
+  border: 1px solid #f97316;
+  background: #fff7ed;
+  color: #c2410c;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.global-map-actions button:hover {
+  background: #f97316;
+  color: #ffffff;
+}
+
+.global-map-frame {
+  position: relative;
+  padding-top: 65%;
+}
+
+.global-map-card.fullscreen .global-map-frame {
+  padding-top: 56.25%;
+}
+
+.global-map-frame iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  border-radius: 0 0 24px 24px;
+}
+
+.global-map-loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  background: rgba(255, 255, 255, 0.85);
+  z-index: 2;
+}
+
+.global-map-loading .spinner {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  border: 4px solid #fde68a;
+  border-top-color: #f97316;
+  animation: spin 1s linear infinite;
+}
+
+.global-map-loading p {
+  color: #475569;
+  font-size: 14px;
+  margin: 0;
+}
+
+.global-map-footer {
+  padding: 16px 24px;
+  border-top: 1px solid #f1f5f9;
+  background: #fff7ed;
+  font-size: 12px;
+  color: #64748b;
+  text-align: center;
+}
+
+.global-sidebar-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 24px;
+  border-bottom: 1px solid #f1f5f9;
+  background: linear-gradient(90deg, rgba(248, 113, 113, 0.1), rgba(255, 255, 255, 0.7));
+}
+
+.global-sidebar-header h3 {
+  font-size: 18px;
+  font-weight: 700;
+  color: #b91c1c;
+  margin: 0;
+}
+
+.global-sidebar-content {
+  padding: 24px;
+  overflow-y: auto;
+  max-height: calc(100vh - 300px);
+}
+
+.global-sidebar-empty {
+  padding: 40px;
+  text-align: center;
+  color: #475569;
+}
+
+.global-country + .global-country {
+  margin-top: 16px;
+}
+
+.global-country-trigger {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  padding: 14px 16px;
+  font-weight: 600;
+  color: #0f172a;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.global-country-trigger.is-selected {
+  border-color: #fb923c;
+  box-shadow: 0 10px 28px rgba(251, 146, 60, 0.2);
+}
+
+.global-country-trigger.expanded {
+  background: #fff7ed;
+}
+
+.global-country-trigger:hover {
+  border-color: #fb923c;
+}
+
+.global-country-icon {
+  transition: transform 0.3s ease;
+}
+
+.global-country-trigger.expanded .global-country-icon {
+  transform: rotate(90deg);
+}
+
+.global-city-list {
+  margin-top: 12px;
+  border-left: 2px solid rgba(251, 146, 60, 0.3);
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.global-city-button {
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  background: #f8fafc;
+  color: #1f2937;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.global-city-button svg {
+  color: #f97316;
+}
+
+.global-city-button:hover {
+  background: #ffe4d6;
+}
+
+.global-city-button.active {
+  background: #fff7ed;
+  border-color: #fb923c;
+  box-shadow: 0 10px 28px rgba(251, 146, 60, 0.15);
+}
+
+.global-city-details {
+  margin-top: 12px;
+  padding: 14px 16px;
+  background: rgba(254, 242, 242, 0.6);
+  border-radius: 14px;
+  border: 1px solid rgba(248, 113, 113, 0.3);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.global-city-detail-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  color: #334155;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.global-city-detail-row a {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.global-city-detail-row a:hover {
+  text-decoration: underline;
+}
+
+.hidden-mobile {
+  display: block;
+}
+
+@media (max-width: 1200px) {
+  .global-presence-layout {
+    flex-direction: column;
+  }
+
+  .global-sidebar-section,
+  .global-map-section {
+    width: 100%;
+  }
+
+  .hidden-mobile {
+    display: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .global-presence-hero {
+    padding: 60px 0 24px;
+  }
+
+  .global-presence-intro h1 {
+    font-size: 32px;
+  }
+
+  .global-presence-intro p {
+    font-size: 16px;
+  }
+
+  .global-presence-layout {
+    padding: 0 16px;
+  }
+
+  .global-sidebar-content {
+    max-height: none;
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/hooks/useIsMobile.js
+++ b/src/hooks/useIsMobile.js
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+
+export const useIsMobile = (breakpoint = 992) => {
+  const getMatches = () =>
+    typeof window !== "undefined" ? window.innerWidth <= breakpoint : false;
+
+  const [isMobile, setIsMobile] = useState(getMatches);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(getMatches());
+    };
+
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [breakpoint]);
+
+  return isMobile;
+};
+
+export default useIsMobile;


### PR DESCRIPTION
## Summary
- add a dedicated Global Presence page that highlights OECL locations with an interactive map and accordion sidebar
- populate the page with structured country and city data alongside custom styling and responsive behaviour
- wire the new page into the application header and router while providing a reusable mobile detection hook

## Testing
- npm run build *(fails: missing local vite dependency in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5a32d35d88330b46bf71487a393f0